### PR TITLE
Add FindSymbolReferences tool for comprehensive symbol reference finding

### DIFF
--- a/RoslynMCP/Tools/RoslynTool.FindSymbolReferences.cs
+++ b/RoslynMCP/Tools/RoslynTool.FindSymbolReferences.cs
@@ -1,0 +1,189 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.FindSymbols;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Text;
+
+namespace RoslynMCP.Tools;
+
+public partial class RoslynTool
+{
+    [McpServerTool, Description("Find all references to a symbol throughout the solution")]
+    public async Task<string> FindSymbolReferences(
+        [Description("Absolute path to the solution file")] string solutionPath,
+        [Description("Path to the file containing the symbol")] string filePath,
+        [Description("Line number (1-based)")] int line, 
+        [Description("Token to find references for")] string tokenToFind)
+    {
+        try
+        {
+            _logger.LogInformation("Finding symbol references at {FilePath}:{Line}:{TokenToFind}", filePath, line, tokenToFind);
+
+            // Get the solution
+            var solution = await _workspaceService.GetSolutionAsync(solutionPath);
+            if (solution == null)
+            {
+                return $"Error: Could not load solution '{solutionPath}'";
+            }
+
+            // Get the document
+            var document = await _workspaceService.GetDocumentAsync(solutionPath, filePath);
+            if (document == null)
+            {
+                return $"Error: Document '{filePath}' not found in solution";
+            }
+
+            var syntaxTree = await document.GetSyntaxTreeAsync();
+            var semanticModel = await document.GetSemanticModelAsync();
+            
+            if (syntaxTree == null || semanticModel == null)
+            {
+                return "Error: Could not get syntax tree or semantic model";
+            }
+
+            // Convert line to text position
+            var sourceText = await syntaxTree.GetTextAsync();
+            var textLines = sourceText.Lines;
+            
+            if (line < 1 || line > textLines.Count)
+            {
+                return $"Error: Line {line} is out of range (1-{textLines.Count})";
+            }
+
+            var textLine = textLines[line - 1];
+            
+            // Find the token on the line using the same method as GetDetailedSymbolInfo
+            var position = await FindTokenPositionOnLine(syntaxTree, textLine, tokenToFind);
+            if (position < 0)
+                return $"Error: Couldn't find token '{tokenToFind}' on line {line}";
+
+            // Get the node at the position
+            var root = await syntaxTree.GetRootAsync();
+            var token = root.FindToken(position);
+            var node = token.Parent;
+            
+            if (node == null)
+            {
+                return "No syntax node found at the specified position";
+            }
+
+            // Get symbol information - try different methods for different syntax kinds
+            ISymbol? targetSymbol = null;
+            
+            // First try GetDeclaredSymbol for declarations (works for class, property, etc.)
+            targetSymbol = semanticModel.GetDeclaredSymbol(node);
+            
+            if (targetSymbol == null)
+            {
+                // For references and other cases, try GetSymbolInfo
+                var symbol = semanticModel.GetSymbolInfo(node);
+                if (symbol.Symbol != null)
+                {
+                    targetSymbol = symbol.Symbol;
+                }
+            }
+            
+            // If still no symbol found, try parent nodes
+            if (targetSymbol == null)
+            {
+                var current = node.Parent;
+                while (current != null && targetSymbol == null)
+                {
+                    // Try GetDeclaredSymbol first
+                    targetSymbol = semanticModel.GetDeclaredSymbol(current);
+                    
+                    if (targetSymbol == null)
+                    {
+                        // Then try GetSymbolInfo
+                        var symbol = semanticModel.GetSymbolInfo(current);
+                        if (symbol.Symbol != null)
+                        {
+                            targetSymbol = symbol.Symbol;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                    
+                    current = current.Parent;
+                }
+            }
+
+            if (targetSymbol == null)
+            {
+                return "No symbol found at the specified location";
+            }
+
+            // Find all references to the symbol
+            var references = await SymbolFinder.FindReferencesAsync(targetSymbol, solution);
+            
+            var result = new StringBuilder();
+            result.AppendLine($"References to '{targetSymbol.Name}' ({targetSymbol.Kind}):");
+            result.AppendLine($"Symbol: {targetSymbol.ToDisplayString()}");
+            result.AppendLine();
+
+            var totalReferences = 0;
+            var fileGroups = new Dictionary<string, List<(int lineNumber, string lineText)>>();
+
+            // Group references by file
+            foreach (var referenceGroup in references)
+            {
+                foreach (var location in referenceGroup.Locations)
+                {
+                    if (location.Location.IsInSource)
+                    {
+                        var referenceDocument = solution.GetDocument(location.Location.SourceTree);
+                        if (referenceDocument != null)
+                        {
+                            var referenceSourceText = await location.Location.SourceTree.GetTextAsync();
+                            var referenceTextLine = referenceSourceText.Lines.GetLineFromPosition(location.Location.SourceSpan.Start);
+                            var lineNumber = referenceTextLine.LineNumber + 1; // Convert to 1-based
+                            var lineText = referenceTextLine.ToString().Trim();
+                            
+                            var fileName = Path.GetRelativePath(Path.GetDirectoryName(solutionPath) ?? "", referenceDocument.FilePath ?? referenceDocument.Name);
+                            
+                            if (!fileGroups.ContainsKey(fileName))
+                            {
+                                fileGroups[fileName] = new List<(int, string)>();
+                            }
+                            
+                            fileGroups[fileName].Add((lineNumber, lineText));
+                            totalReferences++;
+                        }
+                    }
+                }
+            }
+
+            result.AppendLine($"Found {totalReferences} references across {fileGroups.Count} files:");
+            result.AppendLine();
+
+            // Output references grouped by file
+            foreach (var fileGroup in fileGroups.OrderBy(kvp => kvp.Key))
+            {
+                result.AppendLine($"{fileGroup.Key}:");
+                
+                // Sort references by line number within each file
+                foreach (var reference in fileGroup.Value.OrderBy(r => r.lineNumber))
+                {
+                    result.AppendLine($"    {reference.lineNumber}: {reference.lineText}");
+                }
+                result.AppendLine();
+            }
+
+            _logger.LogInformation("Found {TotalReferences} references across {FileCount} files for {Symbol}", 
+                totalReferences, fileGroups.Count, targetSymbol.Name);
+            
+            return result.ToString();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to find symbol references: {FilePath}:{Line}:{TokenToFind}", filePath, line, tokenToFind);
+            return $"Error finding symbol references: {ex.Message}";
+        }
+    }
+
+}

--- a/RoslynMCP/Tools/RoslynTool.GetDetailedSymbolInfo.cs
+++ b/RoslynMCP/Tools/RoslynTool.GetDetailedSymbolInfo.cs
@@ -222,7 +222,7 @@ public partial class RoslynTool
     /// <param name="textLine">The text line to search on</param>
     /// <param name="tokenToFind">The token text to find (case sensitive)</param>
     /// <returns>The absolute position of the token, or -1 if not found</returns>
-    private static async Task<int> FindTokenPositionOnLine(SyntaxTree syntaxTree, TextLine textLine, string tokenToFind)
+    protected static async Task<int> FindTokenPositionOnLine(SyntaxTree syntaxTree, TextLine textLine, string tokenToFind)
     {
         try
         {

--- a/Tests/RoslynMCP.Tests/RoslynToolTests.FindSymbolReferences.cs
+++ b/Tests/RoslynMCP.Tests/RoslynToolTests.FindSymbolReferences.cs
@@ -1,0 +1,285 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RoslynMCP.Services;
+using RoslynMCP.Tools;
+
+namespace RoslynMCP.Tests;
+
+public partial class RoslynToolTests
+{
+    [Test]
+    public async Task FindSymbolReferences_WithValidParameters_CallsWorkspaceService()
+    {
+        // Arrange
+        var solutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        solutionPath = Path.GetFullPath(solutionPath);
+        var filePath = "Program.cs";
+        var line = 52;
+        var tokenToFind = "person";
+        
+        // Setup mock solution and document
+        _mockWorkspaceService
+            .Setup(ws => ws.GetSolutionAsync(solutionPath))
+            .ReturnsAsync(null as Solution);
+        
+        // Act
+        var result = await _roslynTool.FindSymbolReferences(solutionPath, filePath, line, tokenToFind);
+        
+        // Assert
+        _mockWorkspaceService.Verify(ws => ws.GetSolutionAsync(solutionPath), Times.Once);
+        
+        // Verify logging
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains($"Finding symbol references")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task FindSymbolReferences_WithInvalidSolution_ReturnsError()
+    {
+        // Arrange
+        var solutionPath = "NonExistent.sln";
+        var filePath = "Program.cs";
+        var line = 1;
+        var tokenToFind = "someToken";
+        
+        // Setup mock to return null solution
+        _mockWorkspaceService
+            .Setup(ws => ws.GetSolutionAsync(solutionPath))
+            .ReturnsAsync(null as Solution);
+        
+        // Act
+        var result = await _roslynTool.FindSymbolReferences(solutionPath, filePath, line, tokenToFind);
+        
+        // Assert
+        Assert.That(result, Does.Contain("Error: Could not load solution"));
+        
+        // Verify logging
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains($"Finding symbol references")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task FindSymbolReferences_WithPersonVariable_FindsAllUsages()
+    {
+        // Test finding all references to the 'person' variable in TestSln
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test finding references to the 'person' variable
+        var result = await realRoslynTool.FindSymbolReferences(
+            testSolutionPath,
+            "Program.cs",
+            52, // Line with 'var person = new Person'
+            "person"); // The variable name
+
+        // Verify the result contains reference information
+        Assert.That(result, Does.Not.StartWith("Error:"), "Should successfully find person variable references");
+        
+        // Should indicate what symbol we're finding references for
+        Assert.That(result, Does.Contain("References to 'person'"), 
+            "Should indicate which symbol references are being found");
+        
+        // Should contain reference count information
+        Assert.That(result, Does.Contain("Found") & Does.Contain("references"), 
+            "Should contain reference count information");
+        
+        // Should contain file and line number information
+        Assert.That(result, Does.Contain("Program.cs:"), 
+            "Should contain filename in the output");
+        
+        // Should contain line numbers and usage text
+        Assert.That(result, Does.Match(@"\d+:.*person"), 
+            "Should contain line numbers and usage text");
+        
+        realWorkspaceService.Dispose();
+    }
+
+    [Test]
+    public async Task FindSymbolReferences_WithPersonType_FindsAllTypeUsages()
+    {
+        // Test finding all references to the Person type in TestSln
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test finding references to the Person type (the class declaration)
+        var result = await realRoslynTool.FindSymbolReferences(
+            testSolutionPath,
+            "Program.cs",
+            11, // Line with Person class declaration
+            "Person"); // The class name
+
+        // Verify the result contains reference information
+        Assert.That(result, Does.Not.StartWith("Error:"), "Should successfully find Person type references");
+        
+        // Should indicate what symbol we're finding references for
+        Assert.That(result, Does.Contain("References to 'Person'"), 
+            "Should indicate which symbol references are being found");
+        
+        // Should contain multiple references since Person is used in several places
+        Assert.That(result, Does.Contain("Found") & Does.Contain("references"), 
+            "Should contain reference count information");
+        
+        // Should find references in Program.cs
+        Assert.That(result, Does.Contain("Program.cs:"), 
+            "Should find references in Program.cs");
+        
+        // Should find the class declaration and usage in new expression
+        Assert.That(result, Does.Match(@"\d+:.*Person"), 
+            "Should contain line numbers and Person usage");
+        
+        realWorkspaceService.Dispose();
+    }
+
+    [Test]
+    public async Task FindSymbolReferences_WithPropertyName_FindsPropertyUsages()
+    {
+        // Test finding all references to the Name property in TestSln
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test finding references to the Name property
+        var result = await realRoslynTool.FindSymbolReferences(
+            testSolutionPath,
+            "Program.cs",
+            17, // Line with Name property declaration
+            "Name"); // The property name
+
+        // Verify the result contains reference information
+        Assert.That(result, Does.Not.StartWith("Error:"), "Should successfully find Name property references");
+        
+        // Should indicate what symbol we're finding references for
+        Assert.That(result, Does.Contain("References to 'Name'"), 
+            "Should indicate which symbol references are being found");
+        
+        // Should contain reference information
+        Assert.That(result, Does.Contain("Found") & Does.Contain("references"), 
+            "Should contain reference count information");
+        
+        realWorkspaceService.Dispose();
+    }
+
+    [Test]
+    public async Task FindSymbolReferences_WithNonExistentToken_ReturnsError()
+    {
+        // Test with a token that doesn't exist
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test finding references to a non-existent token
+        var result = await realRoslynTool.FindSymbolReferences(
+            testSolutionPath,
+            "Program.cs",
+            11, // Valid line
+            "NonExistentToken"); // Token that doesn't exist
+
+        // Verify the result indicates an error
+        Assert.That(result, Does.StartWith("Error:"), 
+            "Should return error when token is not found");
+        Assert.That(result, Does.Contain("Couldn't find token 'NonExistentToken'"), 
+            "Error message should indicate which token was not found");
+        
+        realWorkspaceService.Dispose();
+    }
+
+    [Test]
+    public async Task FindSymbolReferences_WithInvalidLine_ReturnsError()
+    {
+        // Test with invalid line number
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test with invalid line number
+        var result = await realRoslynTool.FindSymbolReferences(
+            testSolutionPath,
+            "Program.cs",
+            9999, // Invalid line number
+            "someToken");
+
+        // Verify the result indicates an error
+        Assert.That(result, Does.StartWith("Error:"), 
+            "Should return error when line number is invalid");
+        Assert.That(result, Does.Contain("out of range"), 
+            "Error message should indicate line is out of range");
+        
+        realWorkspaceService.Dispose();
+    }
+
+    [Test]
+    public async Task FindSymbolReferences_OutputFormat_IsCorrect()
+    {
+        // Test that the output format matches the specification
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test finding references to person variable
+        var result = await realRoslynTool.FindSymbolReferences(
+            testSolutionPath,
+            "Program.cs",
+            52, // Line with 'var person = new Person'
+            "person"); // The variable name
+
+        // Verify the output format matches specification:
+        // filename:
+        //     linenumber: text of usage
+        
+        Assert.That(result, Does.Not.StartWith("Error:"), "Should successfully find references");
+        
+        // Should have filename followed by colon
+        Assert.That(result, Does.Match(@"Program\.cs:"), 
+            "Should have filename followed by colon");
+        
+        // Should have line numbers indented with usage text
+        Assert.That(result, Does.Match(@"\s+\d+:.*person"), 
+            "Should have indented line numbers with usage text");
+        
+        // Should contain summary information at the top
+        var lines = result.Split('\n');
+        Assert.That(lines[0], Does.Contain("References to 'person'"), 
+            "First line should contain reference summary");
+        
+        realWorkspaceService.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- Add new FindSymbolReferences tool to find all references to symbols across a solution
- Enable comprehensive code navigation and refactoring support by tracking symbol usage
- Share token finding logic between tools for consistency

## Test plan
- [x] Build the solution successfully
- [x] Run all unit tests - 27 tests passing
- [x] Test finding references for variables (person variable)
- [x] Test finding references for types (Person class)
- [x] Test finding references for properties (Name property)
- [x] Test error handling for invalid inputs
- [x] Verify output format matches specification: "filename: linenumber: text of usage"

🤖 Generated with [Claude Code](https://claude.ai/code)