### PR TITLE
Add FindSymbolDeclaration tool for symbol definition navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build and Test Commands
+
+```bash
+# Build the entire solution
+dotnet build
+
+# Run all tests
+dotnet test
+
+# Run tests with detailed output
+dotnet test --verbosity normal
+
+# Run specific test filter
+dotnet test --filter "Name~FindSymbolReferences"
+
+# Run the MCP server (HTTP mode by default)
+dotnet run --project RoslynMCP
+
+# Run the MCP server in stdio mode
+dotnet run --project RoslynMCP -- --stdio
+
+# Run the test client
+dotnet run --project TestApp
+```
+
+## Architecture Overview
+
+### Solution Structure
+- **RoslynMCP**: Main MCP server implementing Roslyn-based code analysis tools
+- **TestApp**: Console client for testing MCP server functionality
+- **Tests/RoslynMCP.Tests**: NUnit test suite for the RoslynMCP tools
+- **TestSln**: Test solution used by unit tests for code analysis scenarios
+
+### Key Architectural Patterns
+
+#### Partial Class Tool Architecture
+The RoslynTool class uses partial classes to organize different tools:
+- `RoslynTool.cs`: Base class with shared functionality
+- `RoslynTool.GetDetailedSymbolInfo.cs`: Symbol information analysis
+- `RoslynTool.GetTypeDocumentation.cs`: Type documentation extraction
+- `RoslynTool.FindSymbolReferences.cs`: Symbol reference finding
+
+#### Shared Token Finding
+The `FindTokenPositionOnLine` method in `RoslynTool.GetDetailedSymbolInfo.cs` is protected and shared across tools for consistent token location.
+
+#### Workspace Service Pattern
+- `IRoslynWorkspaceService` interface for Roslyn workspace operations
+- `RoslynWorkspaceService` implementation handles MSBuildWorkspace management
+- Singleton pattern ensures workspace reuse
+
+### MCP Server Configuration
+- Supports both HTTP (default) and stdio transports
+- Uses System.CommandLine for CLI argument parsing
+- Tools are discovered automatically via `[McpServerTool]` attribute
+- Dependency injection provides ILogger and IRoslynWorkspaceService to tools
+
+### Testing Strategy
+- Unit tests use real Roslyn workspaces with TestSln
+- Tests verify both mock interactions and real workspace operations
+- Test files reference specific line numbers in TestSln/TestProject/Program.cs
+
+## Development Notes
+
+When adding new tools to RoslynTool:
+1. Create a new partial class file: `RoslynTool.YourToolName.cs`
+2. Add the tool method with `[McpServerTool]` attribute
+3. Create corresponding test file: `RoslynToolTests.YourToolName.cs`
+4. Follow existing patterns for error handling and logging
+5. Reuse shared methods like `FindTokenPositionOnLine` when applicable

--- a/RoslynMCP/Tools/RoslynTool.FindSymbolDeclaration.cs
+++ b/RoslynMCP/Tools/RoslynTool.FindSymbolDeclaration.cs
@@ -1,0 +1,286 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.FindSymbols;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Text;
+
+namespace RoslynMCP.Tools;
+
+public partial class RoslynTool
+{
+    [McpServerTool, Description("Find where a symbol is declared and get its type documentation")]
+    public async Task<string> FindSymbolDeclaration(
+        [Description("Absolute path to the solution file")] string solutionPath,
+        [Description("Path to the file containing the symbol")] string filePath,
+        [Description("Line number (1-based)")] int line, 
+        [Description("Token to find declaration for")] string tokenToFind)
+    {
+        try
+        {
+            _logger.LogInformation("Finding symbol declaration at {FilePath}:{Line}:{TokenToFind}", filePath, line, tokenToFind);
+
+            // Get the solution
+            var solution = await _workspaceService.GetSolutionAsync(solutionPath);
+            if (solution == null)
+            {
+                return $"Error: Could not load solution '{solutionPath}'";
+            }
+
+            // Get the document
+            var document = await _workspaceService.GetDocumentAsync(solutionPath, filePath);
+            if (document == null)
+            {
+                return $"Error: Document '{filePath}' not found in solution";
+            }
+
+            var syntaxTree = await document.GetSyntaxTreeAsync();
+            var semanticModel = await document.GetSemanticModelAsync();
+            
+            if (syntaxTree == null || semanticModel == null)
+            {
+                return "Error: Could not get syntax tree or semantic model";
+            }
+
+            // Convert line to text position
+            var sourceText = await syntaxTree.GetTextAsync();
+            var textLines = sourceText.Lines;
+            
+            if (line < 1 || line > textLines.Count)
+            {
+                return $"Error: Line {line} is out of range (1-{textLines.Count})";
+            }
+
+            var textLine = textLines[line - 1];
+            
+            // Find the token on the line using the same method as other tools
+            var position = await FindTokenPositionOnLine(syntaxTree, textLine, tokenToFind);
+            if (position < 0)
+                return $"Error: Couldn't find token '{tokenToFind}' on line {line}";
+
+            // Get the node at the position
+            var root = await syntaxTree.GetRootAsync();
+            var token = root.FindToken(position);
+            var node = token.Parent;
+            
+            if (node == null)
+            {
+                return "No syntax node found at the specified position";
+            }
+
+            // Get symbol information - try different methods for different syntax kinds
+            ISymbol? targetSymbol = null;
+            
+            // First check if we're already on a declaration
+            targetSymbol = semanticModel.GetDeclaredSymbol(node);
+            
+            if (targetSymbol == null)
+            {
+                // Try to get symbol from usage/reference
+                var symbolInfo = semanticModel.GetSymbolInfo(node);
+                targetSymbol = symbolInfo.Symbol;
+            }
+            
+            // If still no symbol found, try parent nodes
+            if (targetSymbol == null)
+            {
+                var current = node.Parent;
+                while (current != null && targetSymbol == null)
+                {
+                    // Try GetDeclaredSymbol first
+                    targetSymbol = semanticModel.GetDeclaredSymbol(current);
+                    
+                    if (targetSymbol == null)
+                    {
+                        // Then try GetSymbolInfo
+                        var symbol = semanticModel.GetSymbolInfo(current);
+                        if (symbol.Symbol != null)
+                        {
+                            targetSymbol = symbol.Symbol;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                    
+                    current = current.Parent;
+                }
+            }
+
+            if (targetSymbol == null)
+            {
+                return "No symbol found at the specified location";
+            }
+
+            // Find the symbol's declaration location(s)
+            var declarations = targetSymbol.DeclaringSyntaxReferences;
+            
+            if (declarations.Length == 0)
+            {
+                // For metadata symbols (like System types), we won't have source locations
+                return BuildMetadataSymbolResult(targetSymbol, solution);
+            }
+
+            // Build the result
+            var result = new StringBuilder();
+            
+            // Get the primary declaration (usually there's only one)
+            var primaryDeclaration = declarations.First();
+            var declarationTree = primaryDeclaration.SyntaxTree;
+            var declarationSourceText = await declarationTree.GetTextAsync();
+            var declarationSpan = primaryDeclaration.Span;
+            var declarationLine = declarationSourceText.Lines.GetLineFromPosition(declarationSpan.Start);
+            
+            // Find which document contains this syntax tree
+            var declarationDocument = solution.GetDocument(declarationTree);
+            if (declarationDocument == null)
+            {
+                return "Error: Could not find document for declaration";
+            }
+
+            var declarationFilePath = declarationDocument.FilePath ?? declarationDocument.Name;
+            var relativeFilePath = Path.GetRelativePath(Path.GetDirectoryName(solutionPath) ?? "", declarationFilePath);
+            
+            result.AppendLine($"Symbol: {targetSymbol.Name}");
+            result.AppendLine($"Kind: {targetSymbol.Kind}");
+            result.AppendLine();
+            result.AppendLine("Declaration:");
+            result.AppendLine($"  File: {relativeFilePath}");
+            result.AppendLine($"  Line: {declarationLine.LineNumber + 1}");
+            result.AppendLine();
+            
+            // Get type documentation using the existing GetTypeDocumentation method
+            if (targetSymbol is INamedTypeSymbol namedType)
+            {
+                var fullyQualifiedName = namedType.ToDisplayString();
+                var typeDocumentation = await GetTypeDocumentation(solutionPath, fullyQualifiedName);
+                result.AppendLine("Type Documentation:");
+                result.AppendLine(typeDocumentation);
+            }
+            else if (targetSymbol is ILocalSymbol local)
+            {
+                // For local variables - handle this case first before checking ContainingType
+                result.AppendLine("Local Variable Information:");
+                result.AppendLine($"  Name: {local.Name}");
+                result.AppendLine($"  Type: {local.Type.ToDisplayString()}");
+                
+                // Get type documentation for the variable's type
+                if (local.Type is INamedTypeSymbol variableType)
+                {
+                    result.AppendLine();
+                    var fullyQualifiedName = variableType.ToDisplayString();
+                    var typeDocumentation = await GetTypeDocumentation(solutionPath, fullyQualifiedName);
+                    result.AppendLine("Variable Type Documentation:");
+                    result.AppendLine(typeDocumentation);
+                }
+            }
+            else if (targetSymbol.ContainingType != null)
+            {
+                // For members of a type, get the containing type's documentation and extract relevant member info
+                var containingType = targetSymbol.ContainingType;
+                result.AppendLine($"Member of: {containingType.ToDisplayString()}");
+                result.AppendLine();
+                
+                // Get member-specific information
+                result.AppendLine("Member Information:");
+                result.AppendLine($"  Name: {targetSymbol.Name}");
+                result.AppendLine($"  Kind: {targetSymbol.Kind}");
+                result.AppendLine($"  Accessibility: {targetSymbol.DeclaredAccessibility}");
+                
+                if (targetSymbol is IPropertySymbol property)
+                {
+                    result.AppendLine($"  Type: {property.Type.ToDisplayString()}");
+                    result.AppendLine($"  Is Read-Only: {property.IsReadOnly}");
+                    result.AppendLine($"  Is Write-Only: {property.IsWriteOnly}");
+                }
+                else if (targetSymbol is IFieldSymbol field)
+                {
+                    result.AppendLine($"  Type: {field.Type.ToDisplayString()}");
+                    result.AppendLine($"  Is Read-Only: {field.IsReadOnly}");
+                    result.AppendLine($"  Is Static: {field.IsStatic}");
+                }
+                else if (targetSymbol is IMethodSymbol method)
+                {
+                    result.AppendLine($"  Return Type: {method.ReturnType.ToDisplayString()}");
+                    result.AppendLine($"  Parameters: {string.Join(", ", method.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"))}");
+                }
+                
+                // Get XML documentation if available
+                var xmlDoc = targetSymbol.GetDocumentationCommentXml();
+                if (!string.IsNullOrWhiteSpace(xmlDoc))
+                {
+                    result.AppendLine();
+                    result.AppendLine("XML Documentation:");
+                    result.AppendLine(xmlDoc);
+                }
+            }
+            
+            _logger.LogInformation("Found declaration for {Symbol} at {File}:{Line}", 
+                targetSymbol.Name, relativeFilePath, declarationLine.LineNumber + 1);
+            
+            return result.ToString();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to find symbol declaration: {FilePath}:{Line}:{TokenToFind}", filePath, line, tokenToFind);
+            return $"Error finding symbol declaration: {ex.Message}";
+        }
+    }
+
+    private string BuildMetadataSymbolResult(ISymbol symbol, Solution solution)
+    {
+        var result = new StringBuilder();
+        
+        result.AppendLine($"Symbol: {symbol.Name}");
+        result.AppendLine($"Kind: {symbol.Kind}");
+        result.AppendLine();
+        result.AppendLine("Declaration:");
+        result.AppendLine($"  Location: Metadata (external assembly)");
+        result.AppendLine($"  Assembly: {symbol.ContainingAssembly?.Name ?? "Unknown"}");
+        result.AppendLine($"  Namespace: {symbol.ContainingNamespace?.ToDisplayString() ?? "Global"}");
+        result.AppendLine();
+        
+        // For metadata symbols, we can still provide type information
+        if (symbol is INamedTypeSymbol namedType)
+        {
+            result.AppendLine("Type Information:");
+            result.AppendLine($"  Full Name: {namedType.ToDisplayString()}");
+            result.AppendLine($"  Base Type: {namedType.BaseType?.ToDisplayString() ?? "None"}");
+            
+            if (namedType.Interfaces.Length > 0)
+            {
+                result.AppendLine($"  Interfaces: {string.Join(", ", namedType.Interfaces.Select(i => i.ToDisplayString()))}");
+            }
+            
+            // Get public members
+            var publicMembers = namedType.GetMembers().Where(m => m.DeclaredAccessibility == Accessibility.Public);
+            if (publicMembers.Any())
+            {
+                result.AppendLine();
+                result.AppendLine("Public Members:");
+                foreach (var member in publicMembers.Take(10)) // Limit to first 10 to avoid huge output
+                {
+                    result.AppendLine($"  - {member.Kind}: {member.Name}");
+                }
+                if (publicMembers.Count() > 10)
+                {
+                    result.AppendLine($"  ... and {publicMembers.Count() - 10} more");
+                }
+            }
+        }
+        
+        // Get XML documentation if available
+        var xmlDoc = symbol.GetDocumentationCommentXml();
+        if (!string.IsNullOrWhiteSpace(xmlDoc))
+        {
+            result.AppendLine();
+            result.AppendLine("XML Documentation:");
+            result.AppendLine(xmlDoc);
+        }
+        
+        return result.ToString();
+    }
+}

--- a/Tests/RoslynMCP.Tests/RoslynToolTests.FindSymbolDeclaration.cs
+++ b/Tests/RoslynMCP.Tests/RoslynToolTests.FindSymbolDeclaration.cs
@@ -1,0 +1,326 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RoslynMCP.Services;
+using RoslynMCP.Tools;
+
+namespace RoslynMCP.Tests;
+
+public partial class RoslynToolTests
+{
+    [Test]
+    public async Task FindSymbolDeclaration_WithValidParameters_CallsWorkspaceService()
+    {
+        // Arrange
+        var solutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        solutionPath = Path.GetFullPath(solutionPath);
+        var filePath = "Program.cs";
+        var line = 52;
+        var tokenToFind = "person";
+        
+        // Setup mock solution and document
+        _mockWorkspaceService
+            .Setup(ws => ws.GetSolutionAsync(solutionPath))
+            .ReturnsAsync(null as Solution);
+        
+        // Act
+        var result = await _roslynTool.FindSymbolDeclaration(solutionPath, filePath, line, tokenToFind);
+        
+        // Assert
+        _mockWorkspaceService.Verify(ws => ws.GetSolutionAsync(solutionPath), Times.Once);
+        // GetDocumentAsync should not be called when solution is null
+        _mockWorkspaceService.Verify(ws => ws.GetDocumentAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        
+        // Verify logging
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains($"Finding symbol declaration")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task FindSymbolDeclaration_WithInvalidSolution_ReturnsError()
+    {
+        // Arrange
+        var solutionPath = "NonExistent.sln";
+        var filePath = "Program.cs";
+        var line = 1;
+        var tokenToFind = "someToken";
+        
+        // Setup mock to return null solution
+        _mockWorkspaceService
+            .Setup(ws => ws.GetSolutionAsync(solutionPath))
+            .ReturnsAsync(null as Solution);
+        
+        // Act
+        var result = await _roslynTool.FindSymbolDeclaration(solutionPath, filePath, line, tokenToFind);
+        
+        // Assert
+        Assert.That(result, Does.Contain("Error: Could not load solution"));
+    }
+
+    [Test]
+    public async Task FindSymbolDeclaration_WithPersonClass_Line11_FindsClassDeclaration()
+    {
+        // Test finding the declaration of Person class from line 11
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test finding declaration of Person class on line 11
+        var result = await realRoslynTool.FindSymbolDeclaration(
+            testSolutionPath,
+            "Program.cs",
+            11, // Line with 'public class Person'
+            "Person"); // The class name
+
+        // Verify the result contains declaration information
+        Assert.That(result, Does.Not.StartWith("Error:"), "Should successfully find Person class declaration");
+        
+        // Should contain symbol information
+        Assert.That(result, Does.Contain("Symbol: Person"), 
+            "Should show the symbol name");
+        Assert.That(result, Does.Contain("Kind: NamedType"), 
+            "Should identify it as a NamedType");
+        
+        // Should contain declaration location
+        Assert.That(result, Does.Contain("Declaration:"), 
+            "Should have a declaration section");
+        Assert.That(result, Does.Contain("File:") & Does.Contain("Program.cs"), 
+            "Should show the file containing the declaration");
+        Assert.That(result, Does.Contain("Line: 11"), 
+            "Should show line 11 as the declaration location");
+        
+        // Should contain type documentation
+        Assert.That(result, Does.Contain("Type Documentation:"), 
+            "Should include type documentation section");
+        
+        realWorkspaceService.Dispose();
+    }
+
+    [Test]
+    public async Task FindSymbolDeclaration_WithNameProperty_Line17_FindsPropertyDeclaration()
+    {
+        // Test finding the declaration of Name property from line 17
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test finding declaration of Name property on line 17
+        var result = await realRoslynTool.FindSymbolDeclaration(
+            testSolutionPath,
+            "Program.cs",
+            17, // Line with 'public string Name { get; set; }'
+            "Name"); // The property name
+
+        // Verify the result contains declaration information
+        Assert.That(result, Does.Not.StartWith("Error:"), "Should successfully find Name property declaration");
+        
+        // Should contain symbol information
+        Assert.That(result, Does.Contain("Symbol: Name"), 
+            "Should show the symbol name");
+        Assert.That(result, Does.Contain("Kind: Property"), 
+            "Should identify it as a Property");
+        
+        // Should contain declaration location
+        Assert.That(result, Does.Contain("Line: 17"), 
+            "Should show line 17 as the declaration location");
+        
+        // Should contain member information
+        Assert.That(result, Does.Contain("Member of: TestProject.Person"), 
+            "Should show it's a member of Person class");
+        Assert.That(result, Does.Contain("Type: string"), 
+            "Should show the property type");
+        
+        realWorkspaceService.Dispose();
+    }
+
+    [Test]
+    public async Task FindSymbolDeclaration_WithAFieldField_Line31_FindsFieldDeclaration()
+    {
+        // Test finding the declaration of aField field from line 31
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test finding declaration of aField field on line 31
+        var result = await realRoslynTool.FindSymbolDeclaration(
+            testSolutionPath,
+            "Program.cs",
+            31, // Line with 'public int aField = 0;'
+            "aField"); // The field name
+
+        // Verify the result contains declaration information
+        Assert.That(result, Does.Not.StartWith("Error:"), "Should successfully find aField field declaration");
+        
+        // Should contain symbol information
+        Assert.That(result, Does.Contain("Symbol: aField"), 
+            "Should show the symbol name");
+        Assert.That(result, Does.Contain("Kind: Field"), 
+            "Should identify it as a Field");
+        
+        // Should contain declaration location
+        Assert.That(result, Does.Contain("Line: 31"), 
+            "Should show line 31 as the declaration location");
+        
+        // Should contain member information
+        Assert.That(result, Does.Contain("Member of: TestProject.Person"), 
+            "Should show it's a member of Person class");
+        Assert.That(result, Does.Contain("Type: int"), 
+            "Should show the field type");
+        
+        realWorkspaceService.Dispose();
+    }
+
+    [Test]
+    public async Task FindSymbolDeclaration_WithPersonVariable_Line52_FindsVariableDeclaration()
+    {
+        // Test finding the declaration of person variable used on line 59, declared on line 52
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test finding declaration of person variable from its usage on line 59
+        var result = await realRoslynTool.FindSymbolDeclaration(
+            testSolutionPath,
+            "Program.cs",
+            59, // Line with usage: 'string json = JsonConvert.SerializeObject(person, Formatting.Indented);'
+            "person"); // The variable name
+
+        // Verify the result contains declaration information
+        Assert.That(result, Does.Not.StartWith("Error:"), "Should successfully find person variable declaration");
+        
+        // Should contain symbol information
+        Assert.That(result, Does.Contain("Symbol: person"), 
+            "Should show the symbol name");
+        Assert.That(result, Does.Contain("Kind: Local"), 
+            "Should identify it as a Local variable");
+        
+        // Should contain declaration location
+        Assert.That(result, Does.Contain("Line: 52"), 
+            "Should show line 52 as the declaration location");
+        
+        // Should contain variable information
+        Assert.That(result, Does.Contain("Local Variable Information:"), 
+            "Should have local variable section");
+        Assert.That(result, Does.Contain("Type: TestProject.Person"), 
+            "Should show the variable type");
+        
+        // Should contain type documentation for the variable's type
+        Assert.That(result, Does.Contain("Variable Type Documentation:"), 
+            "Should include documentation for the variable's type");
+        
+        realWorkspaceService.Dispose();
+    }
+
+    [Test]
+    public async Task FindSymbolDeclaration_WithInvalidLine_ReturnsError()
+    {
+        // Test with invalid line number
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test with invalid line number
+        var result = await realRoslynTool.FindSymbolDeclaration(
+            testSolutionPath,
+            "Program.cs",
+            9999, // Invalid line number
+            "someToken");
+
+        // Verify the result indicates an error
+        Assert.That(result, Does.StartWith("Error:"), 
+            "Should return error when line number is invalid");
+        Assert.That(result, Does.Contain("out of range"), 
+            "Error message should indicate line is out of range");
+        
+        realWorkspaceService.Dispose();
+    }
+
+    [Test]
+    public async Task FindSymbolDeclaration_WithNonExistentToken_ReturnsError()
+    {
+        // Test with a token that doesn't exist
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test finding a non-existent token
+        var result = await realRoslynTool.FindSymbolDeclaration(
+            testSolutionPath,
+            "Program.cs",
+            11, // Valid line
+            "NonExistentToken"); // Token that doesn't exist
+
+        // Verify the result indicates an error
+        Assert.That(result, Does.StartWith("Error:"), 
+            "Should return error when token is not found");
+        Assert.That(result, Does.Contain("Couldn't find token 'NonExistentToken'"), 
+            "Error message should indicate which token was not found");
+        
+        realWorkspaceService.Dispose();
+    }
+
+    [Test]
+    public async Task FindSymbolDeclaration_WithMetadataSymbol_ReturnsMetadataInfo()
+    {
+        // Test finding declaration of a System type (like Console)
+        var realWorkspaceService = new RoslynWorkspaceService(
+            new Mock<ILogger<RoslynWorkspaceService>>().Object);
+        
+        var realRoslynTool = new RoslynTool(_mockLogger.Object, realWorkspaceService);
+        
+        var testSolutionPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "TestSln", "TestSln.sln");
+        testSolutionPath = Path.GetFullPath(testSolutionPath);
+
+        // Test finding declaration of Console (metadata symbol)
+        var result = await realRoslynTool.FindSymbolDeclaration(
+            testSolutionPath,
+            "Program.cs",
+            48, // Line with 'Console.WriteLine(...)'
+            "Console"); // System.Console
+
+        // Verify the result contains metadata information
+        Assert.That(result, Does.Not.StartWith("Error:"), "Should successfully find Console metadata");
+        
+        // Should contain symbol information
+        Assert.That(result, Does.Contain("Symbol: Console"), 
+            "Should show the symbol name");
+        
+        // Should indicate it's from metadata
+        Assert.That(result, Does.Contain("Location: Metadata"), 
+            "Should indicate it's from metadata/external assembly");
+        Assert.That(result, Does.Contain("Namespace: System"), 
+            "Should show the System namespace");
+        
+        realWorkspaceService.Dispose();
+    }
+}

--- a/ToDo.md
+++ b/ToDo.md
@@ -1,4 +1,19 @@
-- This test GetDetailedSymbolInfo_WithPersonType_IncludesInheritanceInformation isn't returning the public interface information.
+Add a new tool to RoslynTools that will find where a symbol is declared
+- This tool will take the same params as GetDetailedSymbolInfo
+- It will return the following format
+filename where the symbol is declared
+line number: line number where the symbol was declared
+type info for the symbol by calling GetTypeDocumentation
 
-- The GetDetailedSymbolInfo function can just call GetDetailedTypeInfo once it has the fully qualified type name, rather than reimpmeneting the functionality.
-- Add a test to get person from line 52, the variable, rather than the Type
+- This needs to work on class declarations so
+class MyClass
+if it asks for the declaration of MyClass on that line, it should be able to figure out the type information for MyClass, and return its public interface
+
+- Write unit tests using TestSln
+ - Line 11 Person - class declaration
+ - Line 17 Name - Property Declaration
+ - Line 31 aField - field declaration
+ - Line 59 person - a variable use declared on Line 51 of type Person.
+ 
+ - Build and fix any errors
+ - Run tests and fix any errors


### PR DESCRIPTION
## Summary
- Add new FindSymbolDeclaration tool to locate where symbols are declared in the codebase
- Provide comprehensive type documentation and declaration information
- Support all symbol types: classes, properties, fields, variables, and metadata symbols
- Complete the symbol navigation feature set alongside FindSymbolReferences

## Features
- Find declaration location for any symbol (file path and line number)
- Get full type documentation including public interface
- Handle both source code symbols and metadata symbols (external assemblies)
- Consistent parameter interface with other RoslynTools

## Test plan
- [x] Build the solution successfully  
- [x] Run all unit tests - 36 tests passing
- [x] Test finding class declarations (Person class on line 11)
- [x] Test finding property declarations (Name property on line 17)
- [x] Test finding field declarations (aField on line 31)
- [x] Test finding variable declarations (person variable usage on line 59)
- [x] Test metadata symbols (System.Console)
- [x] Verify error handling for invalid inputs

🤖 Generated with [Claude Code](https://claude.ai/code)